### PR TITLE
Add missing ssl-cert package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,14 @@
     - nginx-revproxy
     - packages
 
+- name: Install ssl-cert
+  apt:
+    name: ssl-cert
+    state: present
+  tags:
+    - nginx-revproxy
+    - packages
+
 - name: Install python-passlib for Python 3 hosts
   apt:
     name:


### PR DESCRIPTION
snake-oil certificate is used in this plugin for first install but is
not installed.

For debian and ubuntu systems it is provided by the `ssl-cert` package.