### PR TITLE
Do not intercept everything under `/.well-known`

### DIFF
--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -48,8 +48,8 @@ server {
    return         301 https://$server_name$request_uri;
    }
 
-   location /.well-known {
-      alias /var/www/{{ item.key }}/.well-known;
+   location /.well-known/acme-challenge {
+      alias /var/www/{{ item.key }}/.well-known/acme-challenge;
    }
 
    access_log /var/log/nginx/{{ item.key }}_access.log;
@@ -78,8 +78,8 @@ server {
    ssl_prefer_server_ciphers on;
    ssl_session_cache shared:SSL:10m;
 
-   location /.well-known {
-      alias /var/www/{{ item.key }}/.well-known;
+   location /.well-known/acme-challenge {
+      alias /var/www/{{ item.key }}/.well-known/acme-challenge;
    }
 
    location / {

--- a/templates/reverseproxy_ssl_letsencrypt.conf.j2
+++ b/templates/reverseproxy_ssl_letsencrypt.conf.j2
@@ -17,8 +17,8 @@ server {
    return         301 https://$server_name$request_uri;
    }
 
-   location /.well-known {
-      alias /var/www/{{ item.key }}/.well-known;
+   location /.well-known/acme-challenge {
+      alias /var/www/{{ item.key }}/.well-known/acme-challenge;
    }
 
    access_log /var/log/nginx/{{ item.key }}_access.log;
@@ -47,8 +47,8 @@ server {
    ssl_prefer_server_ciphers on;
    ssl_session_cache shared:SSL:10m;
 
-   location /.well-known {
-      alias /var/www/{{ item.key }}/.well-known;
+   location /.well-known/acme-challenge {
+      alias /var/www/{{ item.key }}/.well-known/acme-challenge;
    }
 
    location / {


### PR DESCRIPTION
Some HTTP based protocols or implementaitons (for instance CardDav and
CalDav) are using `/.well-known` as well.
This change allows to use the reverse proxy even for services relying on
`/.well-known` subpaths