### PR TITLE
Support for http2

### DIFF
--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -5,8 +5,8 @@
 
 {% if item.key == "default" %}
 server {
-    listen        80 default_server;
-    listen   [::]:80 default_server;
+    listen        80 http2 default_server;
+    listen   [::]:80 http2 default_server;
     server_name _;
     return        444;
 
@@ -23,8 +23,8 @@ upstream {{ item.key }}_backend  {
 }
 
 server {
-   listen         80;
-   listen    [::]:80;
+   listen         80 http2;
+   listen    [::]:80 http2;
    server_name    {{ item.value.domains | join(' ') }};
 
    location / {

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -5,8 +5,8 @@
 
 {% if item.key == "default" %}
 server {
-    listen        80 default_server;
-    listen   [::]:80 default_server;
+    listen        80 http2 default_server;
+    listen   [::]:80 http2 default_server;
     server_name _;
     return        444;
 

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -41,8 +41,8 @@ upstream {{ item.key }}_backend  {
 }
 
 server {
-   listen         80;
-   listen    [::]:80;
+   listen         80 http2;
+   listen    [::]:80 http2;
    server_name    {{ item.value.domains | join(' ') }};
    location / {
    return         301 https://$server_name$request_uri;
@@ -58,8 +58,8 @@ server {
 }
 
 server {
-   listen        443 ssl;
-   listen   [::]:443 ssl;
+   listen        443 http2 ssl;
+   listen   [::]:443 http2 ssl;
    server_name {{ item.value.domains | join(' ') }};
 
 {% if item.value.hsts_max_age is defined %}

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -16,8 +16,8 @@ server {
 }
 
 server {
-   listen        443 ssl default_server;
-   listen   [::]:443 ssl default_server;
+   listen        443 ssl http2 default_server;
+   listen   [::]:443 ssl http2 default_server;
    server_name _;
    return        444;
 

--- a/templates/reverseproxy_ssl_letsencrypt.conf.j2
+++ b/templates/reverseproxy_ssl_letsencrypt.conf.j2
@@ -10,8 +10,8 @@ upstream {{ item.key }}_backend  {
 }
 
 server {
-   listen         80;
-   listen    [::]:80;
+   listen         80 http2;
+   listen    [::]:80 http2;
    server_name    {{ item.value.domains | join(' ') }};
    location / {
    return         301 https://$server_name$request_uri;

--- a/templates/reverseproxy_ssl_letsencrypt.conf.j2
+++ b/templates/reverseproxy_ssl_letsencrypt.conf.j2
@@ -27,8 +27,8 @@ server {
 }
 
 server {
-   listen        443 ssl;
-   listen   [::]:443 ssl;
+   listen        443 ssl http2;
+   listen   [::]:443 ssl http2;
    server_name {{ item.value.domains | join(' ') }};
 
 {% if item.value.hsts_max_age is defined %}


### PR DESCRIPTION
since http v1 is no longer up-to-date, nginx support for http2 should be activated (by default).