### PR TITLE
Remove http2 support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,18 @@
   when:
     - ansible_python['version']['major'] == 2
 
+- name: Set up nginx directories
+  file:
+    path: "/etc/nginx/{{ item }}"
+    state: directory
+    owner: root
+    group: root
+  with_items:
+    - sites-available
+    - sites-enabled
+  tags:
+    - nginxrevproxy
+
 - name: Add authentication
   htpasswd:
     path: "/etc/nginx/{{ item.key }}_htpasswd"

--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -5,8 +5,8 @@
 
 {% if item.key == "default" %}
 server {
-    listen        {{ item.value.listen | default(80) }} http2 default_server;
-    listen   [::]:{{ item.value.listen | default(80) }} http2 default_server;
+    listen        {{ item.value.listen | default(80) }} default_server;
+    listen   [::]:{{ item.value.listen | default(80) }} default_server;
     server_name _;
     return        444;
 
@@ -23,8 +23,8 @@ upstream {{ item.key }}_backend  {
 }
 
 server {
-   listen         {{ item.value.listen | default(80) }} http2;
-   listen    [::]:{{ item.value.listen | default(80) }} http2;
+   listen         {{ item.value.listen | default(80) }};
+   listen    [::]:{{ item.value.listen | default(80) }};
    server_name    {{ item.value.domains | join(' ') }};
 
    location / {

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -5,8 +5,8 @@
 
 {% if item.key == "default" %}
 server {
-    listen        {{ item.value.listen | default(80) }} http2 default_server;
-    listen   [::]:{{ item.value.listen | default(80) }} http2 default_server;
+    listen        {{ item.value.listen | default(80) }} default_server;
+    listen   [::]:{{ item.value.listen | default(80) }} default_server;
     server_name _;
     return        444;
 
@@ -16,8 +16,8 @@ server {
 }
 
 server {
-   listen        {{ item.value.listen_ssl | default(443) }} ssl http2 default_server;
-   listen   [::]:{{ item.value.listen_ssl | default(443) }} ssl http2 default_server;
+   listen        {{ item.value.listen_ssl | default(443) }} ssl default_server;
+   listen   [::]:{{ item.value.listen_ssl | default(443) }} ssl default_server;
    server_name _;
    return        444;
 
@@ -41,8 +41,8 @@ upstream {{ item.key }}_backend  {
 }
 
 server {
-   listen         {{ item.value.listen | default(80) }} http2;
-   listen    [::]:{{ item.value.listen | default(80) }} http2;
+   listen         {{ item.value.listen | default(80) }}; 
+   listen    [::]:{{ item.value.listen | default(80) }};
    server_name    {{ item.value.domains | join(' ') }};
    location / {
    return         301 https://$server_name$request_uri;
@@ -58,8 +58,8 @@ server {
 }
 
 server {
-   listen        {{ item.value.listen_ssl | default(443) }} ssl http2;
-   listen   [::]:{{ item.value.listen_ssl | default(443) }} ssl http2;
+   listen        {{ item.value.listen_ssl | default(443) }} ssl;
+   listen   [::]:{{ item.value.listen_ssl | default(443) }} ssl;
    server_name {{ item.value.domains | join(' ') }};
 
 {% if item.value.hsts_max_age is defined %}

--- a/templates/reverseproxy_ssl_letsencrypt.conf.j2
+++ b/templates/reverseproxy_ssl_letsencrypt.conf.j2
@@ -10,8 +10,8 @@ upstream {{ item.key }}_backend  {
 }
 
 server {
-   listen         {{ item.value.listen | default(80) }} http2;
-   listen    [::]:{{ item.value.listen | default(80) }} http2;
+   listen         {{ item.value.listen | default(80) }};
+   listen    [::]:{{ item.value.listen | default(80) }};
    server_name    {{ item.value.domains | join(' ') }};
    location / {
    return         301 https://$server_name$request_uri;
@@ -27,8 +27,8 @@ server {
 }
 
 server {
-   listen        {{ item.value.listen_ssl | default(443) }} ssl http2;
-   listen   [::]:{{ item.value.listen_ssl | default(443) }} ssl http2;
+   listen        {{ item.value.listen_ssl | default(443) }} ssl;
+   listen   [::]:{{ item.value.listen_ssl | default(443) }} ssl;
    server_name {{ item.value.domains | join(' ') }};
 
 {% if item.value.hsts_max_age is defined %}


### PR DESCRIPTION
I was getting LetsEncrypt failures because of the http2 support in the nginx conf files.

```Server is speaking HTTP/2 over HTTP```

```
Challenge failed for domain <DOMAIN>
http-01 challenge for <DOMAIN>
Cleaning up challenges
Some challenges have failed.
IMPORTANT NOTES:
 - The following errors were reported by the server:
   Domain: <DOMAIN>
   Type:   connection
   Detail: Fetching
   <DOMAIN>/.well-known/acme-challenge/oRibOmkn64XrF8-98e33o-BMc8ju7vcGY7WbeIAMD9o:
   Server is speaking HTTP/2 over HTTP
   To fix these errors, please make sure that your domain name was
   entered correctly and the DNS A/AAAA record(s) for that domain
   contain(s) the right IP address. Additionally, please check that
   your computer has a publicly routable IP address and that no
   firewalls are preventing the server from communicating with the
   client. If you're using the webroot plugin, you should also verify
   that you are serving files from the webroot path you provided.
```

I think there's a chance the http2 support could just be removed for the LE challenges but I'm not totally sure how to make that happen, completely removing it did the trick for me at least.