### PR TITLE
Remove X-Forwarded-Ssl header on nginx non-ssl template configuration

### DIFF
--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -29,7 +29,6 @@ server {
 
    location / {
       gzip off;
-      proxy_set_header X-Forwarded-Ssl on;
       client_max_body_size {{ item.value.client_max_body_size | default('50M') }};
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";


### PR DESCRIPTION
When using the non-SSL nginx configuration, the X-Forwarded-Ssl header set to 'on' generates HTTP 400 on all requests with the following error message: 

> Contradictory scheme headers

IMO, it's not needed in this template and it's safe to remove.