### PR TITLE
Add ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     # - MOLECULE_DISTRO: centos7
     - MOLECULE_DISTRO: ubuntu1604
     - MOLECULE_DISTRO: ubuntu1804
+    - MOLECULE_DISTRO: ubuntu2004
     - MOLECULE_DISTRO: debian9
     - MOLECULE_DISTRO: debian10
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
       versions:
         - xenial
         - bionic
+        - focal
 
   galaxy_tags:
     - development


### PR DESCRIPTION
My git fu failed me. It closed my previous PR #22 . I was trying to reorder my commit to the end

lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04 LTS
Release:	20.04
Codename:	focal

Closes #21