### PR TITLE
Allow to install certbot from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ nginx_revproxy_sites:                                         # List of sites to
     ssl_certificate_key: /etc/ssl/private/ssl-cert-snakeoil.key # ssl certificate key, used if letsencrypt is false
     letsencrypt: false                                        # Set to True if you want use letsencrypt
     letsencrypt_email: ""                                     # Set email for letencrypt cert
+
+nginx_revproxy_certbot_auto: true                             # Install certbot-auto
+
+nginx_revproxy_certbot_packages:                              # Install these packages from repo, when not using certbot-auto
+  - certbot
+  - python3-certbot-nginx
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,9 @@ nginx_revproxy_sites:                                         # List of sites to
     hsts_max_age: 63072000                                    # Set HSTS header with max-age defined
     letsencrypt: false                                        # Set to True if you want use letsencrypt
     letsencrypt_email: ""                                     # Set email for letencrypt cert
+
+nginx_revproxy_certbot_auto: true
+
+nginx_revproxy_certbot_packages:
+  - certbot
+  - python3-certbot-nginx

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -1,10 +1,20 @@
 ---
 
-- name: Install certbot
+- name: Install certbot-auto
   get_url:
     url: https://dl.eff.org/certbot-auto
     dest: /usr/bin/certbot-auto
     mode: "a+x"
+  when: nginx_revproxy_certbot_auto
+  tags:
+    - lesencrypt
+    - nginxrevproxy
+
+- name: Install certbot from repository
+  apt:
+    name: "{{ nginx_revproxy_certbot_packages }}"
+    state: present
+  when: not nginx_revproxy_certbot_auto
   tags:
     - lesencrypt
     - nginxrevproxy
@@ -60,7 +70,7 @@
 
 - name: Generate certs (first time)
   command: |
-    certbot-auto certonly
+    certbot{{ '-auto' if nginx_revproxy_certbot_auto else '' }} certonly
     --webroot -w /var/www/{{ item.key }}
     -d {{ item.value.domains | join(' -d ') }}
     --email {{ item.value.letsencrypt_email }}
@@ -89,7 +99,8 @@
 - name: Insert cert-bot renew in crontab
   cron:
     name: "cert-bot renew"
-    job: 'certbot-auto renew --post-hook "systemctl reload nginx" >> /var/log/letsencrypt/letsencrypt-update.log 2>&1'
+    job: "certbot{{ '-auto' if nginx_revproxy_certbot_auto else '' }} \
+renew --post-hook \"systemctl reload nginx\" >> /var/log/letsencrypt/letsencrypt-update.log 2>&1"
     hour: "3"
     minute: "30"
     weekday: "1"


### PR DESCRIPTION
* Keep default behavior
* Allow to install certbot from repository
* Package defaults work at least for current Debian and Ubuntu
* Addresses #29 