### PR TITLE
Add an option to prevent connections from being upgraded.

### DIFF
--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -32,7 +32,9 @@ server {
       client_max_body_size {{ item.value.client_max_body_size | default('50M') }};
       proxy_read_timeout {{ item.value.proxy_read_timeout | default('300') }};
       proxy_set_header Upgrade $http_upgrade;
+{% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
       proxy_set_header Connection "upgrade";
+{% endif %}
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -94,7 +94,9 @@ server {
       client_max_body_size {{ item.value.client_max_body_size | default('50M') }};
       proxy_read_timeout {{ item.value.proxy_read_timeout | default('300') }};
       proxy_set_header Upgrade $http_upgrade;
+{% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
       proxy_set_header Connection "upgrade";
+{% endif %}
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Not all web servers support the `Connection upgrade` header values and results in Bad Things (e.g., [Kestrel](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-5.0)). This update allows the header to not be sent. It leaves the default value as `Connection upgrade` to maintain backwards-compatibility with existing code.