### PR TITLE
Removed deprecated certbot-auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ nginx_revproxy_sites:                                         # List of sites to
     letsencrypt: false                                        # Set to True if you want use letsencrypt
     letsencrypt_email: ""                                     # Set email for letencrypt cert
 
-nginx_revproxy_certbot_auto: true                             # Install certbot-auto
-
-nginx_revproxy_certbot_packages:                              # Install these packages from repo, when not using certbot-auto
+nginx_revproxy_certbot_packages:                              # Install these packages from repo
   - certbot
   - python3-certbot-nginx
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,6 @@ nginx_revproxy_sites:                                         # List of sites to
     letsencrypt: false                                        # Set to True if you want use letsencrypt
     letsencrypt_email: ""                                     # Set email for letencrypt cert
 
-nginx_revproxy_certbot_auto: true
-
 nginx_revproxy_certbot_packages:
   - certbot
   - python3-certbot-nginx

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -1,20 +1,8 @@
 ---
-
-- name: Install certbot-auto
-  get_url:
-    url: https://dl.eff.org/certbot-auto
-    dest: /usr/bin/certbot-auto
-    mode: "a+x"
-  when: nginx_revproxy_certbot_auto
-  tags:
-    - lesencrypt
-    - nginxrevproxy
-
 - name: Install certbot from repository
   apt:
     name: "{{ nginx_revproxy_certbot_packages }}"
     state: present
-  when: not nginx_revproxy_certbot_auto
   tags:
     - lesencrypt
     - nginxrevproxy
@@ -73,7 +61,7 @@
 
 - name: Generate certs (first time)
   command: |
-    certbot{{ '-auto' if nginx_revproxy_certbot_auto else '' }} certonly
+    certbot certonly
     --webroot -w /var/www/{{ item.key }}
     -d {{ item.value.domains | join(' -d ') }}
     --email {{ item.value.letsencrypt_email }}
@@ -103,8 +91,7 @@
 - name: Insert cert-bot renew in crontab
   cron:
     name: "cert-bot renew"
-    job: "certbot{{ '-auto' if nginx_revproxy_certbot_auto else '' }} \
-renew --post-hook \"systemctl reload nginx\" >> /var/log/letsencrypt/letsencrypt-update.log 2>&1"
+    job: "certbot renew --post-hook \"systemctl reload nginx\" >> /var/log/letsencrypt/letsencrypt-update.log 2>&1"
     hour: "3"
     minute: "30"
     weekday: "1"


### PR DESCRIPTION
certbot-auto is deprecated since 1.10.0 release https://community.letsencrypt.org/t/certbot-auto-no-longer-works-on-debian-based-systems/139702/7