### PR TITLE
removed deprecated 'ssl on' directive

### DIFF
--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -69,7 +69,6 @@ server {
    access_log /var/log/nginx/{{ item.key }}_access.log;
    error_log /var/log/nginx/{{ item.key }}_error.log error;
 
-   ssl on;
 {% if not __skip_letsencrypt | default(false) and item.value.letsencrypt is defined and item.value.letsencrypt %}
    ssl_certificate /etc/letsencrypt/live/{{ item.key }}/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/{{ item.key }}/privkey.pem;


### PR DESCRIPTION
`ssl on|off` directive was deprecated in version 1.15.0.
http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl