### PR TITLE
Added CORS support for rev-proxy APIs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ nginx_revproxy_sites:                                         # List of sites to
     hsts_max_age: 63072000                                    # Set HSTS header with max-age defined
     letsencrypt: false                                        # Set to True if you want use letsencrypt
     letsencrypt_email: ""                                     # Set email for letencrypt cert
+    allow_cors: false                                         # Set to True if you want to allow Cross-Origin requests
 
 nginx_revproxy_certbot_auto: false
 

--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -29,7 +29,7 @@ server {
 
 {% if item.value.allow_cors is defined and item.value.allow_cors %}
    add_header 'Access-Control-Allow-Origin' $http_origin;
-   add_header 'Access-Control-Max-Age' 1728000;
+   add_header 'Access-Control-Max-Age' 600;
 {% endif %}
 
    location / {

--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -27,6 +27,11 @@ server {
    listen    [::]:{{ item.value.listen | default(80) }};
    server_name    {{ item.value.domains | join(' ') }};
 
+{% if item.value.allow_cors is defined and item.value.allow_cors %}
+   add_header 'Access-Control-Allow-Origin' $http_origin;
+   add_header 'Access-Control-Max-Age' 1728000;
+{% endif %}
+
    location / {
       gzip off;
       client_max_body_size {{ item.value.client_max_body_size | default('50M') }};

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -69,7 +69,6 @@ server {
    access_log /var/log/nginx/{{ item.key }}_access.log;
    error_log /var/log/nginx/{{ item.key }}_error.log error;
 
-   ssl on;
 {% if not __skip_letsencrypt | default(false) and item.value.letsencrypt is defined and item.value.letsencrypt %}
    ssl_certificate /etc/letsencrypt/live/{{ item.key }}/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/{{ item.key }}/privkey.pem;

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -68,7 +68,7 @@ server {
 
 {% if item.value.allow_cors is defined and item.value.allow_cors %}
    add_header 'Access-Control-Allow-Origin' $http_origin;
-   add_header 'Access-Control-Max-Age' 1728000;
+   add_header 'Access-Control-Max-Age' 600;
 {% endif %}
 
 

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -71,7 +71,6 @@ server {
    add_header 'Access-Control-Max-Age' 600;
 {% endif %}
 
-
    access_log /var/log/nginx/{{ item.key }}_access.log;
    error_log /var/log/nginx/{{ item.key }}_error.log error;
 

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -66,6 +66,12 @@ server {
    add_header Strict-Transport-Security "max-age={{ item.value.hsts_max_age }}; includeSubDomains; preload" always;
 {% endif %}
 
+{% if item.value.allow_cors is defined and item.value.allow_cors %}
+   add_header 'Access-Control-Allow-Origin' $http_origin;
+   add_header 'Access-Control-Max-Age' 1728000;
+{% endif %}
+
+
    access_log /var/log/nginx/{{ item.key }}_access.log;
    error_log /var/log/nginx/{{ item.key }}_error.log error;
 


### PR DESCRIPTION
Added new flag `allow_cors: <bool>` which enables Cross-Origin requests for proxied API. Without this flag enabled only requests from the same to Api host domains are allowed in browser.
```
nginx_revproxy_sites:
  example.com:
    ...
    allow_cors: <bool | default( false )>
```

When enabled force nginx to add following headers to response
```
   add_header 'Access-Control-Allow-Origin' $http_origin;
   add_header 'Access-Control-Max-Age' 600;
```

`Access-Control-Allow-Origin` set to `$http_origin` which is equal to value from `Origin` header in request
`Access-Control-Max-Age` set to 10 min period accordingly to Chromium v76 and below cap

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age