### PR TITLE
Added 'proxy_http_version 1.1' header when connection is upgraded

### DIFF
--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -33,6 +33,7 @@ server {
       proxy_read_timeout {{ item.value.proxy_read_timeout | default('300') }};
       proxy_set_header Upgrade $http_upgrade;
 {% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
+      proxy_http_version 1.1;
       proxy_set_header Connection "upgrade";
 {% endif %}
       proxy_set_header Host $http_host;

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -93,6 +93,7 @@ server {
       proxy_read_timeout {{ item.value.proxy_read_timeout | default('300') }};
       proxy_set_header Upgrade $http_upgrade;
 {% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
+      proxy_http_version 1.1;
       proxy_set_header Connection "upgrade";
 {% endif %}
       proxy_set_header Host $http_host;


### PR DESCRIPTION
Proxied websocket connection requires http version 1.1. Without this clients trying connect to proxied websocket will receive
```Handshake ended with HTTP error: 400```

http://nginx.org/en/docs/http/websocket.html