### PR TITLE
Add option to add Upstream Hostname

### DIFF
--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -35,7 +35,7 @@ server {
 {% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
       proxy_set_header Connection "upgrade";
 {% endif %}
-      proxy_set_header Host $http_host;
+      proxy_set_header Host {{ item.value.upstream_hostname | default('$http_host') }};
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -95,7 +95,7 @@ server {
 {% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
       proxy_set_header Connection "upgrade";
 {% endif %}
-      proxy_set_header Host $http_host;
+      proxy_set_header Host {{ item.value.upstream_hostname | default('$http_host') }};
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Whilst setting up a reverse proxy, I found I needed to send a specific hostname to the upstream server.

This patch adds the ability to do that, whilst maintaining previous functionality as default.