### PR TITLE
support adding extra locations in reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ nginx_revproxy_sites:                                         # List of sites to
     auth:                                                     # Define this block for a single HTTP user/password, or leave undefined for unauthenticated vhosts
       login: myusername
       password: mysecretpassword
+    extra_location:                                           # Set this block to add extra location, or leave it undefined for non extra location needed
+      websocket:                                              # extra location name
+        upstreams:                                            # list of upstreans for extra location
+          - { backend_address: 192.168.0.102, backend_port: 8088 }
     listen: 9000                                              # Specify which port you want to listen to with clear HTTP, or leave undefined for 80
     ssl: false                                                # Set to True if you want to redirect http to https
     letsencrypt: false                                        # Set to True if you want to use letsencrypt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,11 @@ nginx_revproxy_sites:                                         # List of sites to
     upstreams:                                                # List of Upstreams
       - {backend_address: 192.168.0.100, backend_port: 80}
       - {backend_address: 192.168.0.101, backend_port: 8080}
+    # extra_location:
+    #   websocket:
+    #     upstreams:
+    #       - {backend_address: 192.168.0.102, backend_port: 8088}
+
     ssl: true                                                 # Set to True if you want to redirect http to https
     hsts_max_age: 63072000                                    # Set HSTS header with max-age defined
     letsencrypt: false                                        # Set to True if you want use letsencrypt

--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -22,6 +22,16 @@ upstream {{ item.key }}_backend  {
 {% endfor %}
 }
 
+{% if item.value.extra_locations is defined %}
+{% for extra_location in item.value.extra_locations %}
+upstream {{ item.key }}_{{ extra_location }}_backend  {
+{% for extra_upstream in item.value.extra_locations[extra_location].upstreams %}
+   server {{ extra_upstream.backend_address }}:{{ extra_upstream.backend_port }};
+{% endfor %}
+}
+{% endfor %}
+{% endif %}
+
 server {
    listen         {{ item.value.listen | default(80) }};
    listen    [::]:{{ item.value.listen | default(80) }};
@@ -46,6 +56,25 @@ server {
       auth_basic_user_file /etc/nginx/{{ item.key }}_htpasswd;
 {% endif %}
    }
+
+{% if item.value.extra_locations is defined %}
+{% for extra_location in item.value.extra_locations %}
+   location /{{ extra_location }} {
+      gzip off;
+      client_max_body_size {{ item.value.client_max_body_size | default('50M') }};
+      proxy_read_timeout {{ item.value.proxy_read_timeout | default('300') }};
+      proxy_pass http://{{ item.key }}_{{ extra_location }}_backend;
+      proxy_http_version  1.1;
+      proxy_set_header        Upgrade $http_upgrade;
+{% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
+      proxy_set_header        Connection "upgrade";
+{% endif %}
+      proxy_set_header        Host $http_host;
+      proxy_set_header        X-Real-IP $remote_addr;
+   }
+
+{% endfor %}
+{% endif %}
 
    location /.well-known {
       alias /var/www/{{ item.key }}/.well-known;

--- a/templates/reverseproxy_ssl.conf.j2
+++ b/templates/reverseproxy_ssl.conf.j2
@@ -36,9 +36,19 @@ server {
 {% else %}
 upstream {{ item.key }}_backend  {
 {% for upstream in item.value.upstreams %}
-    server {{upstream.backend_address}}:{{upstream.backend_port}};
+   server {{ upstream.backend_address }}:{{ upstream.backend_port }};
 {% endfor %}
 }
+
+{% if item.value.extra_locations is defined %}
+{% for extra_location in item.value.extra_locations %}
+upstream {{ item.key }}_{{ extra_location }}_backend  {
+{% for extra_upstream in item.value.extra_locations[extra_location].upstreams %}
+   server {{ extra_upstream.backend_address }}:{{ extra_upstream.backend_port }};
+{% endfor %}
+}
+{% endfor %}
+{% endif %}
 
 server {
    listen         {{ item.value.listen | default(80) }};
@@ -106,5 +116,24 @@ server {
       auth_basic_user_file /etc/nginx/{{ item.key }}_htpasswd;
 {% endif %}
    }
+
+{% if item.value.extra_locations is defined %}
+{% for extra_location in item.value.extra_locations %}
+   location /{{ extra_location }} {
+      gzip off;
+      client_max_body_size {{ item.value.client_max_body_size | default('50M') }};
+      proxy_read_timeout {{ item.value.proxy_read_timeout | default('300') }};
+      proxy_pass http://{{ item.key }}_{{ extra_location }}_backend;
+      proxy_http_version  1.1;
+      proxy_set_header        Upgrade $http_upgrade;
+{% if item.value.conn_upgrade is not defined or item.value.conn_upgrade %}
+      proxy_set_header        Connection "upgrade";
+{% endif %}
+      proxy_set_header        Host $http_host;
+      proxy_set_header        X-Real-IP $remote_addr;
+   }
+
+{% endfor %}
+{% endif %}
 }
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Calvin Pham <calvin@inboxs.com>

We have a scenrio as both webserver and websocket running in the same domain name.
ie. example.com and example.com/websocket
They are using the same FQDN but difference paths for difference services
By supporting extra location, We can solve this problem.
