### PR TITLE
FIX: Use the same default values for every tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,8 +87,8 @@
     siteconfig
   when:
     - nginxinstalled is success
-    - not item.value.ssl | default(True)
-    - not item.value.letsencrypt | default(True)
+    - not item.value.ssl | default(False)
+    - not item.value.letsencrypt | default(False)
   tags:
     - nginxrevproxy
 
@@ -105,7 +105,7 @@
   when:
     - nginxinstalled is success
     - item.value.ssl | default(False)
-    - not item.value.letsencrypt | default(True)
+    - not item.value.letsencrypt | default(False)
   tags:
     - nginxrevproxy
 
@@ -138,7 +138,7 @@
   notify: Reload Nginx
   when:
     - siteconfig is success
-    - not item.value.letsencrypt | default(True)
+    - not item.value.letsencrypt | default(False)
     - not ansible_check_mode
   tags:
     - nginxrevproxy


### PR DESCRIPTION
Use the same default values for `ssl` & `letsencrypt` items in `nginx_revproxy_sites` dictionary, otherwise you have to always define this keys or get a wired state.

For example if you only define `ssl` `true` no site configuration is generated.