### PR TITLE
Fix: typo of extra_location key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ nginx_revproxy_sites:                                         # List of sites to
     auth:                                                     # Define this block for a single HTTP user/password, or leave undefined for unauthenticated vhosts
       login: myusername
       password: mysecretpassword
-    extra_location:                                           # Set this block to add extra location, or leave it undefined for non extra location needed
+    extra_locations:                                           # Set this block to add extra location, or leave it undefined for non extra location needed
       websocket:                                              # extra location name
         upstreams:                                            # list of upstreans for extra location
           - { backend_address: 192.168.0.102, backend_port: 8088 }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ nginx_revproxy_sites:                                         # List of sites to
     upstreams:                                                # List of Upstreams
       - {backend_address: 192.168.0.100, backend_port: 80}
       - {backend_address: 192.168.0.101, backend_port: 8080}
-    # extra_location:
+    # extra_locations:
     #   websocket:
     #     upstreams:
     #       - {backend_address: 192.168.0.102, backend_port: 8088}


### PR DESCRIPTION
Extra location is implemented with `extra_locations`. But in `README.md` and `default.yml`, it is typo mistake and mentioned `extra_location`. 